### PR TITLE
Use the same name for the transliterate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ slugify('你好, world!'); // ni-hao-world
 ```html
 <!-- ESM build -->
 <script type="module">
-  import { transl } from 'https://cdn.jsdelivr.net/npm/transliteration@2.0.4/dist/browser/bundle.esm.min.js';
-  console.log(transl('你好'));
+  import { transliterate } from 'https://cdn.jsdelivr.net/npm/transliteration@2.0.4/dist/browser/bundle.esm.min.js';
+  console.log(transliterate('你好'));
 </script>
 ```
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,2 +1,2 @@
 import { slugify, transliterate } from '../node';
-export { transliterate as transl, slugify };
+export { transliterate as transl, transliterate, slugify };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,5 +91,6 @@ export type SlugifyFunction = TransliterationFunction<OptionsSlugify>;
 
 export interface BrowserGlobalObject {
   transl: TransliterateFunction;
+  transliterate: TransliterateFunction;
   slugify: SlugifyFunction;
 }


### PR DESCRIPTION
We are using next.js, which automatically picks up the bundle based on whether the code is running in node or in the browser.

Thus, neither

```javascript
import { transliterate } from 'transliteration';
```

nor

```javascript
import { transl } from 'transliteration';
```

works because the former code would only successfully run on the server, while the latter only in the browser.

This PR aligns the two bundles, using `transliterate` as name for both. The old function name has been kept for backwards compatibility.

Open question: what exactly was the purpose for renaming `transliterate` to `transl` when storing it on the window?